### PR TITLE
update compat entry for ChunkSplitters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ ProfileLikelihoodDelaunayTriangulationExt = "DelaunayTriangulation"
 ProfileLikelihoodMakieExt = "Makie"
 
 [compat]
-ChunkSplitters = "1.0"
+ChunkSplitters = "1.0, 2.0"
 Contour = "0.6"
 FunctionWrappers = "1.1"
 Interpolations = "0.14"


### PR DESCRIPTION

We released a formally breaking version of ChunkSplitters (v2.0.0), but which does not affect most users. It won´t affect your package, so here I'm proposing the update of the compat entry to accept the 2.0 version.

